### PR TITLE
Change stability warning

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -278,7 +278,7 @@ OpenEOClient <- R6Class(
         cat("Please check the terms of service (terms_of_service()) and the privacy policy (privacy_policy()). By further usage of this service, you acknowledge and agree to those terms and policies.\n")
         
         if (!hostInfo[hostInfo$url == private$host,]$production) {
-          message("Warning: Connected host is considered unstable and not production-ready. Unexpected errors might occur.")
+          message("Warning: Connected host is not production-ready. Unexpected errors might occur.")
         }
         
         tryCatch({


### PR DESCRIPTION
The R client gives a message if production is set to false by a back-end:
"Connected host is considered unstable and not production-ready"

In D34 it is said that this is confusing as it's not clear what exactly is unstable (connection? back-end?).

I'd propose to change the wording a bit to "Connected host is not production-ready".