### PR TITLE
Simpler login + fix default_client(s)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,10 @@
 ## Changed
 * replaced package `httr` by `httr2` to include the device_code and PKCE authentication methods
 * `connect` no longer carries the login parameters separately, but uses `...` to pass on those information
-* adapted the setting of required parameters on login, e.g. `login_type='basic'|'oidc'` will be deduced based on additional parameters
+
+## Removed
+
+* login parameter `login_type` removed. type will be deduced based on the other parameters.
 
 # version 1.1.1
 

--- a/R/authentication.R
+++ b/R/authentication.R
@@ -255,15 +255,6 @@ AbstractOIDCAuthentication <- R6Class(
       
       private$getEndpoints()
       
-      if ("default_client" %in% names(provider)) {
-        default_client = provider[["default_client"]]
-        # id, redirect_urls, grant_types
-        config$client_id = default_client[["id"]]
-        private$isGrantTypeSupported(default_client$grant_types)
-      }
-      
-      
-      
       if (!(is.list(config) && all(c("client_id") %in% names(config)))) {
         stop("'client_id' is not present in the configuration.")
       }

--- a/R/authentication.R
+++ b/R/authentication.R
@@ -554,7 +554,7 @@ OIDCAuthCodeFlow <- R6Class(
 )
 
 .get_oidc_provider = function(provider) {
-  if (is.character(provider)) {
+  if (length(provider) > 0 && is.character(provider)) {
     oidc_providers = list_oidc_providers()
     if (provider %in% names(oidc_providers)) {
       return(oidc_providers[[provider]])
@@ -564,4 +564,16 @@ OIDCAuthCodeFlow <- R6Class(
   }
   
   return(provider)
+}
+
+.get_client = function(clients, grant, config) {
+  supported = which(sapply(clients, function(p) grant %in% p$grant_types))
+  if (length(supported) > 0) {
+    config$client_id = clients[[supported[[1]]]]$id
+    config$grant_type = grant
+    return(config)
+  }
+  else {
+    return (NULL)
+  }
 }

--- a/R/client.R
+++ b/R/client.R
@@ -24,7 +24,7 @@ NULL
 #'   \item{\code{$stopIfNotConnected()}}{throws an error if called and the client is not connected}
 #'   \item{\code{$connect(url=NULL,version=NULL)}}{connects to a specific version of a back-end}
 #'   \item{\code{$api_version()}}{returns the openEO API version this client is compliant to}
-#'   \item{\code{$login(login_type = NULL,user=NULL, password=NULL,provider=NULL,config=NULL)}}{creates an \code{\link{IAuth}} object based on the login_type}
+#'   \item{\code{$login(user=NULL, password=NULL,provider=NULL,config=NULL)}}{creates an \code{\link{IAuth}} object}
 #'   \item{\code{$logout()}}{invalidates the access_token and terminates the current session}
 #'   \item{\code{$getAuthClient()}}{returns the authentication client}
 #'   \item{\code{$setAuthClient(value)}}{sets the authentication client if it was configured and set externally}
@@ -46,7 +46,7 @@ NULL
 #'   \item{\code{version}}{the openEO API version to be used, or a list of available API versions if set to NULL}
 #'   \item{\code{user}}{the user name}
 #'   \item{\code{password}}{the user password}
-#'   \item{\code{login_type}}{'basic', 'oidc' or NULL to control the authentication}
+#'   \item{\code{login_type}}{Deprecated. Nor used anymore.}
 #'   \item{\code{value}}{an authentication object}
 #' }
 NULL
@@ -306,42 +306,27 @@ OpenEOClient <- R6Class(
     api_version = function () {
       return(private$version)
     },
-    login=function(login_type = NULL,user=NULL, password=NULL,provider=NULL,config=NULL) {
-      if (!is.null(user) && !is.null(password) && is.null(login_type)) {
-        # then it should be "basic"
-        login_type = "basic"
-      }
-      
-      if (!is.null(provider) && is.null(login_type)) {
-        login_type = "oidc"
-      } 
-      
-      if (is.null(provider) && !is.null(login_type) && login_type=="oidc") {
-        providers = list_oidc_providers()
-        provider = providers[[1]]
-      }
-      
+    # login_type is deprecated and unused.
+    login = function(login_type=NULL, user=NULL, password=NULL, provider=NULL, config=NULL) {
       self$stopIfNotConnected()
-      if (is.null(login_type)) {
-        message("No login type specified. Use 'basic' or 'oidc'.")
-        return(invisible(self))
-      }
       
       tryCatch({
-        login_type = tolower(login_type)
-        
-        if (!is.null(login_type) && !login_type %in% c("basic","oidc") ) {
-          stop("Cannot find the login mechanism type. Please use 'basic' or 'oidc'")
+        if (!is.null(user) && !is.null(password)) {
+          private$loginBasic(user=user, password = password)
+        }
+        else {
+          if (is.null(provider)) {
+            providers = list_oidc_providers()
+            provider = providers[[1]]
+            if (is_null(provider)) {
+              message("Either a provider needs to be provided, or a username and password for basic authentication.")
+              return(invisible(self))
+            }
+          }
+          private$loginOIDC(provider = provider, config = config)
         }
         
-        if (login_type == "oidc") {
-          private$loginOIDC(provider = provider, config = config)
-        } else if (login_type == "basic") {
-          private$loginBasic(user=user, password = password)
-        } 
-        
         invisible(self)
-        
       },
       error=.capturedErrorToMessage)
     },
@@ -482,51 +467,48 @@ OpenEOClient <- R6Class(
             
             if (length(config) > 0 && !is.list(config)) stop("parameter 'config' is not a named list")
             
-            if (length(config) > 0 && all(c("client_id","secret") %in% names(config))) {
-              private$auth_client = OIDCAuthCodeFlow$new(provider=provider,
-                                                         config = config,force=TRUE)
-            } else if (length(config) > 0 && "grant_type" %in% names(config)) {
-              grants = config[["grant_type"]]
-            } else if (length(config) == 0 || !"grant_type" %in% names(config)) { 
-              # get default client
-              if ("default_client" %in% names(provider)) {
-                default_client = provider[["default_client"]]
-                # id, redirect_urls, grant_types
+            if (length(config) > 0 && (all(c("client_id","secret") %in% names(config)) || config$grant_type == 'authorization_code')) {
+              private$auth_client = OIDCAuthCodeFlow$new(provider=provider, config = config, force=TRUE)
+            } else if (length(config) == 0 && "default_clients" %in% names(provider) && length(provider[["default_clients"]]) > 0) {
+              default_clients = provider[["default_clients"]]
+
+              get_client <- function(clients, grant, config) {
+                supported <- which(sapply(clients, function(p) grant %in% p$grant_types))
+                if (length(supported) > 0) {
+                  config$client_id <- clients[[supported[[1]]]]$id
+                  config$grant_type <- grant
+                  return(config)
+                }
+                else {
+                  return (NULL)
+                }
               }
-              # check maybe for others or user has to specify, which I don't like
               
-              if (length(default_client) > 0) {
-                grants = default_client$grant_types
-                
-                # get grants
+              if ("grant_type" %in% config) {
+                config <- get_client(default_clients, config$grant_type, config)
+              }
+              else {
                 # preferred device code + pkce
                 # second auth_code + pkce
-                # third auth_code with secret
-                
-                if (!any(c("urn:ietf:params:oauth:grant-type:device_code+pkce",
-                           "authorization_code+pkce", 
-                           "authorization_code") %in% grants)) {
-                  stop("None of device_code+pkce, authorization_code+pkce or authorization_code are offered the authentication provider.")
+                config <- get_client(default_clients, "urn:ietf:params:oauth:grant-type:device_code+pkce", config)
+                if (is_null(config$client_id)) {
+                  config <- get_client(default_clients, "authorization_code+pkce", config)
                 }
-                
-                
+              }
+              
+              if (is_null(config$client_id)) {
+                stop("Please provide a client ID, or both a client ID and client secret for the Authorization Code + PKCE grant.")
               }
             }
               
-            if ( "urn:ietf:params:oauth:grant-type:device_code+pkce" %in% grants) {
-              private$auth_client = OIDCDeviceCodeFlowPkce$new(provider=provider,
-                                                               config = config)
-            } else if ("authorization_code+pkce" %in% grants) {
-              private$auth_client = OIDCAuthCodeFlowPKCE$new(provider=provider,
-                                                             config = config)
-            } else if ("authorization_code" %in% grants) {
-              private$auth_client = OIDCAuthCodeFlow$new(provider=provider,
-                                                         config = config)
+            if ( "urn:ietf:params:oauth:grant-type:device_code+pkce" == config$grant_type) {
+              private$auth_client = OIDCDeviceCodeFlowPkce$new(provider=provider, config = config)
+            } else if ("authorization_code+pkce" == config$grant_type) {
+              private$auth_client = OIDCAuthCodeFlowPKCE$new(provider=provider, config = config)
             } else {
-              stop("Unsupported grant_type(s):",paste0(grants,collapse=", "))
+              stop("The grant_type selected is missing or not supported")
             }
-              
-            
+
             private$auth_client$login()
             cat("Login successful.\n")
             

--- a/R/client.R
+++ b/R/client.R
@@ -46,7 +46,6 @@ NULL
 #'   \item{\code{version}}{the openEO API version to be used, or a list of available API versions if set to NULL}
 #'   \item{\code{user}}{the user name}
 #'   \item{\code{password}}{the user password}
-#'   \item{\code{login_type}}{Deprecated. Nor used anymore.}
 #'   \item{\code{value}}{an authentication object}
 #' }
 NULL
@@ -465,19 +464,19 @@ OpenEOClient <- R6Class(
             # probably fetch resolve the potential string into a provider here
             provider = .get_oidc_provider(provider)
             
-            auth_pkce <- "authorization_code+pkce"
-            device_pkce <- "urn:ietf:params:oauth:grant-type:device_code+pkce"
+            auth_pkce = "authorization_code+pkce"
+            device_pkce = "urn:ietf:params:oauth:grant-type:device_code+pkce"
             
-            has_default_clients <- "default_clients" %in% names(provider) && length(provider[["default_clients"]]) > 0
-            client_id_given <- "client_id" %in% names(config)
+            has_default_clients = "default_clients" %in% names(provider) && length(provider[["default_clients"]]) > 0
+            client_id_given = "client_id" %in% names(config)
             
             if (length(config) > 0)  {
               if (!is.list(config))  {
                 stop("parameter 'config' is not a named list")
               }
               
-              full_credentials <- all(c("client_id","secret") %in% names(config))
-              is_auth_code <- length(config$grant_type) > 0 && config$grant_type == 'authorization_code'
+              full_credentials = all(c("client_id","secret") %in% names(config))
+              is_auth_code = length(config$grant_type) > 0 && config$grant_type == 'authorization_code'
               
               if (full_credentials && (is_auth_code || is.null(config$grant_type))) {
                 private$auth_client = OIDCAuthCodeFlow$new(provider = provider, config = config, force=TRUE)
@@ -489,12 +488,12 @@ OpenEOClient <- R6Class(
                 default_clients = provider[["default_clients"]]
                 # If a client_id is given, check whether we can use device code + pkce.
                 # Otherwise, fall back to auth code + pkce (for backward compatibility)
-                supported <- which(sapply(default_clients, function(p) config$client_id == p$id))
+                supported = which(sapply(default_clients, function(p) config$client_id == p$id))
                 if (length(supported) > 0 && device_pkce %in% default_clients[[supported[[1]]]]$grant_types) {
-                  config$grant_type <- device_pkce
+                  config$grant_type = device_pkce
                 }
                 else {
-                  config$grant_type <- auth_pkce
+                  config$grant_type = auth_pkce
                 }
               }
             }
@@ -502,28 +501,16 @@ OpenEOClient <- R6Class(
             if (has_default_clients && !client_id_given) {
               default_clients = provider[["default_clients"]]
 
-              get_client <- function(clients, grant, config) {
-                supported <- which(sapply(clients, function(p) grant %in% p$grant_types))
-                if (length(supported) > 0) {
-                  config$client_id <- clients[[supported[[1]]]]$id
-                  config$grant_type <- grant
-                  return(config)
-                }
-                else {
-                  return (NULL)
-                }
-              }
-              
               # check whether user has chosen a grant type
               if ("grant_type" %in% names(config)) {
-                config <- get_client(default_clients, config$grant_type, config)
+                config = .get_client(default_clients, config$grant_type, config)
               }
               else {
                 # preferred device code + pkce
-                config <- get_client(default_clients, device_pkce, config)
+                config = .get_client(default_clients, device_pkce, config)
                 # second choice auth_code + pkce
                 if (is.null(config$client_id)) {
-                  config <- get_client(default_clients, auth_pkce, config)
+                  config = .get_client(default_clients, auth_pkce, config)
                 }
               }
               

--- a/R/client.R
+++ b/R/client.R
@@ -458,18 +458,48 @@ OpenEOClient <- R6Class(
       
       private$host = host
     },
-    loginOIDC = function(provider=NULL, config = NULL) {
+    loginOIDC = function(provider = NULL, config = NULL) {
       suppressWarnings({
         tryCatch({
             # old implementation
             # probably fetch resolve the potential string into a provider here
             provider = .get_oidc_provider(provider)
             
-            if (length(config) > 0 && !is.list(config)) stop("parameter 'config' is not a named list")
+            auth_pkce <- "authorization_code+pkce"
+            device_pkce <- "urn:ietf:params:oauth:grant-type:device_code+pkce"
             
-            if (length(config) > 0 && (all(c("client_id","secret") %in% names(config)) || config$grant_type == 'authorization_code')) {
-              private$auth_client = OIDCAuthCodeFlow$new(provider=provider, config = config, force=TRUE)
-            } else if (length(config) == 0 && "default_clients" %in% names(provider) && length(provider[["default_clients"]]) > 0) {
+            has_default_clients <- "default_clients" %in% names(provider) && length(provider[["default_clients"]]) > 0
+            client_id_given <- "client_id" %in% names(config)
+            
+            if (length(config) > 0)  {
+              if (!is.list(config))  {
+                stop("parameter 'config' is not a named list")
+              }
+              
+              full_credentials <- all(c("client_id","secret") %in% names(config))
+              is_auth_code <- length(config$grant_type) > 0 && config$grant_type == 'authorization_code'
+              
+              if (full_credentials && (is_auth_code || is.null(config$grant_type))) {
+                private$auth_client = OIDCAuthCodeFlow$new(provider = provider, config = config, force=TRUE)
+              }
+              else if (is_auth_code) {
+                stop("For grant type 'authorization_code' a client_id and secret must be provided")
+              }
+              else if (client_id_given && has_default_clients) {
+                default_clients = provider[["default_clients"]]
+                # If a client_id is given, check whether we can use device code + pkce.
+                # Otherwise, fall back to auth code + pkce (for backward compatibility)
+                supported <- which(sapply(default_clients, function(p) config$client_id == p$id))
+                if (length(supported) > 0 && device_pkce %in% default_clients[[supported[[1]]]]$grant_types) {
+                  config$grant_type <- device_pkce
+                }
+                else {
+                  config$grant_type <- auth_pkce
+                }
+              }
+            }
+            
+            if (has_default_clients && !client_id_given) {
               default_clients = provider[["default_clients"]]
 
               get_client <- function(clients, grant, config) {
@@ -484,29 +514,32 @@ OpenEOClient <- R6Class(
                 }
               }
               
-              if ("grant_type" %in% config) {
+              # check whether user has chosen a grant type
+              if ("grant_type" %in% names(config)) {
                 config <- get_client(default_clients, config$grant_type, config)
               }
               else {
                 # preferred device code + pkce
-                # second auth_code + pkce
-                config <- get_client(default_clients, "urn:ietf:params:oauth:grant-type:device_code+pkce", config)
-                if (is_null(config$client_id)) {
-                  config <- get_client(default_clients, "authorization_code+pkce", config)
+                config <- get_client(default_clients, device_pkce, config)
+                # second choice auth_code + pkce
+                if (is.null(config$client_id)) {
+                  config <- get_client(default_clients, auth_pkce, config)
                 }
               }
               
-              if (is_null(config$client_id)) {
-                stop("Please provide a client ID, or both a client ID and client secret for the Authorization Code + PKCE grant.")
+              if (is.null(config$client_id)) {
+                stop("Please provide a client id or a valid combination of client_id and grant_type.")
               }
             }
               
-            if ( "urn:ietf:params:oauth:grant-type:device_code+pkce" == config$grant_type) {
+            if (device_pkce == config$grant_type) {
               private$auth_client = OIDCDeviceCodeFlowPkce$new(provider=provider, config = config)
-            } else if ("authorization_code+pkce" == config$grant_type) {
+            } else if (is.null(config$grant_type) || auth_pkce == config$grant_type) {
               private$auth_client = OIDCAuthCodeFlowPKCE$new(provider=provider, config = config)
-            } else {
-              stop("The grant_type selected is missing or not supported")
+            }
+            
+            if (is.null(private$auth_client)) {
+              stop("The grant_type selected is not supported")
             }
 
             private$auth_client$login()

--- a/R/user.R
+++ b/R/user.R
@@ -176,10 +176,10 @@ describe_account = function(con=NULL) {
 #' processing functions. For any computation and the creation of web services, you need to register the openEO partner of
 #' your choice. There you will get further information on credentials and the log in procedure.
 #' 
-#' Especially the \code{authType} suggested by the client development guidelines are confusing.
-#' 'Basic' allows you to use user name and password directly in the call, whereas 'oidc' will
-#' open a browser window, where you enter you credentials. The authentication on all protected endpoints will later
-#' use the bearer token that the client has obtained after the log in, unless the authentication was dropped with NULL.
+#' The \code{...} parameter allows you to pass on arguments directly for \code{\link{login}}. If they are omitted the 
+#' client will only connect to the back-end, but does not do authentication. The user must do that manually afterwards. 
+#' Based on the provided login parameters user / password or OIDC provider the appropriate login procedure for basic authentication
+#' or OIDC authentication will be chosen.
 #' 
 #' The parameter \code{version} is not required. If the service offers a well-known document of the
 #' service the client will choose an appropriate version (default the most recent production ready version).
@@ -269,7 +269,6 @@ connect = function(host, version = NULL, exchange_token="access_token", ...) {
 #' is used.
 #' @param user the user name
 #' @param password the password
-#' @param login_type Deprecated. Not used anymore.
 #' @param provider provider object as obtained by 'list_oidc_providers()' or the name of the provider in the provider list. If NULL
 #' and \code{provider_type="oidc"} then the first available provider is chosen from the list.
 #' @param config named list containing 'client_id' and 'secret' or a path to the configuration file (type JSON). If NULL and 
@@ -296,7 +295,7 @@ connect = function(host, version = NULL, exchange_token="access_token", ...) {
 #' 
 #' }
 #' @export
-login = function(user = NULL, password = NULL, login_type = NULL, provider=NULL, config=NULL, con=NULL) {
+login = function(user = NULL, password = NULL, provider=NULL, config=NULL, con=NULL) {
     tryCatch({
         con = .assure_connection(con)
         

--- a/R/user.R
+++ b/R/user.R
@@ -176,8 +176,8 @@ describe_account = function(con=NULL) {
 #' processing functions. For any computation and the creation of web services, you need to register the openEO partner of
 #' your choice. There you will get further information on credentials and the log in procedure.
 #' 
-#' Especially the \code{login_type} and the \code{authType} suggested by the client development guidelines are confusing. Here the login_type deals 
-#' with considered log in. 'Basic' allows you to use user name and password directly in the call, whereas 'oidc' will
+#' Especially the \code{authType} suggested by the client development guidelines are confusing.
+#' 'Basic' allows you to use user name and password directly in the call, whereas 'oidc' will
 #' open a browser window, where you enter you credentials. The authentication on all protected endpoints will later
 #' use the bearer token that the client has obtained after the log in, unless the authentication was dropped with NULL.
 #' 
@@ -204,12 +204,10 @@ describe_account = function(con=NULL) {
 #' # connect to a host by direct URL and basic log in
 #' con = connect(host='http://example.openeo.org/v1.0',
 #'               user='user',
-#'              password='password',
-#'              login_type='basic')
+#'              password='password')
 #' 
 #' # connect to a host with open id connect authentication
-#' con = connect(host='http://example.openeo.org',
-#'               login_type='oidc')
+#' con = connect(host='http://example.openeo.org')
 #'
 #' # connect and login with a named and valid oidc provider
 #' con = connect(host='http://example.openeo.org',
@@ -245,11 +243,11 @@ connect = function(host, version = NULL, exchange_token="access_token", ...) {
 #' @details 
 #' Based on the general login type (\link{BasicAuth} or \link{OIDCAuth}) there need to be different configurations. The basic
 #' authentication (if supported) is the simplest login mechanism for which user need to enter their credentials directly as
-#' \code{user} and \code{password}. The login_type can be neglected if those two parameters are set.
+#' \code{user} and \code{password}.
 #' 
 #' For the Open ID connect authentication the user needs to select one of the accepted OIDC providers of 
-#' \code{\link{list_oidc_providers}} as \code{provider}. Alternatively the name of the provider suffices. The login type can be
-#' neglected if a valid provider was selected. For further configuration, you can pass a named list of values as \code{config} or
+#' \code{\link{list_oidc_providers}} as \code{provider}. Alternatively the name of the provider suffices.
+#' For further configuration, you can pass a named list of values as \code{config} or
 #' a file path to a JSON file.
 #' 
 #' There are many different authentication mechanisms for OIDC and OAuth2.0, which OIDC is based on. The 'openeo' package supports
@@ -271,9 +269,7 @@ connect = function(host, version = NULL, exchange_token="access_token", ...) {
 #' is used.
 #' @param user the user name
 #' @param password the password
-#' @param login_type either NULL, 'basic' or 'oidc'. This refers to the login mechanism that shall be used. 
-#' If the parameter is NULL the authentication method is chosen by the stated other parameters (provider -> oidc, 
-#' user/password -> basic)
+#' @param login_type Deprecated. Not used anymore.
 #' @param provider provider object as obtained by 'list_oidc_providers()' or the name of the provider in the provider list. If NULL
 #' and \code{provider_type="oidc"} then the first available provider is chosen from the list.
 #' @param config named list containing 'client_id' and 'secret' or a path to the configuration file (type JSON). If NULL and 
@@ -286,16 +282,16 @@ connect = function(host, version = NULL, exchange_token="access_token", ...) {
 #' # the URL won't work and is just to demonstrate how to write the code
 #' con = connect(host='http://example.openeo.org',version='1.0.0')
 #' 
-#' # credentials are dummy values
-#' login(user='user',password='password',login_type='basic', con=con)
+#' # some back-ends support logging in throug OIDC without any parameters
+#' login()
 #' 
-#' # also valid basic authentication
+#' # basic authentication, credentials are dummy values
 #' login(user='user',password='password')
 #' 
-#' # or alternatively the oidc login
-#' login(login_type='oidc', provider=provider, config=config)
+#' # or alternatively the OIDC login
+#' login(provider=provider, config=config)
 #' 
-#' # with device_code+pkce enabled at the oidc provider you can even use this
+#' # with device_code+pkce enabled at the OIDC provider you can even use this
 #' login(provider="your_named_provider")
 #' 
 #' }
@@ -304,7 +300,7 @@ login = function(user = NULL, password = NULL, login_type = NULL, provider=NULL,
     tryCatch({
         con = .assure_connection(con)
         
-        return(con$login(user = user, password = password, login_type = login_type, provider = provider, config=config))
+        return(con$login(user = user, password = password, provider = provider, config=config))
     }, error = .capturedErrorToMessage)
 }
 

--- a/examples/EURAC-examples.Rmd
+++ b/examples/EURAC-examples.Rmd
@@ -19,7 +19,7 @@ password = ""
 
 api_versions(url=euracHost)
 
-eurac = connect(host = euracHost, version="0.4.2", user = user,password = password, login_type = "basic")
+eurac = connect(host = euracHost, version="0.4.2", user = user,password = password)
 ```
 
 Explorative calls as described in the Use Case 1.
@@ -149,7 +149,7 @@ pwd = ""
 
 host_url = "https://openeo.eurac.edu"
 
-eurac = connect(host = host_url, version="0.4.2", user = user, password = pwd, login_type = "basic")
+eurac = connect(host = host_url, version="0.4.2", user = user, password = pwd)
 ```
 
 ```{r}

--- a/examples/GEE-examples.Rmd
+++ b/examples/GEE-examples.Rmd
@@ -18,7 +18,7 @@ api_versions(gee_host_url)
 ```
 
 ```{r}
-gee = connect(host = gee_host_url, version="1.0.1",user = user,password = pwd,login_type = "basic")
+gee = connect(host = gee_host_url, version="1.0.1",user = user,password = pwd)
 ```
 
 `gee` is a connection to an openEO service. Starting with openeo (v0.6.0) it is no longer required to use the connection on most of the client functions, due to the use of `active_connection`. However, if you use multiple services at once you should pass the intended connection, because `active_connection` will only hold the latest connected services.
@@ -618,7 +618,7 @@ pwd = "test123"
 
 gee_host_url = "https://earthengine.openeo.org"
 
-gee = connect(host = gee_host_url, version="1.0.0-rc.2",user = user,password = pwd,login_type = "basic")
+gee = connect(host = gee_host_url, version="1.0.0-rc.2",user = user,password = pwd)
 
 
 # Then we obtain the tools to work with the provided openEO processes. We do this via `processes()`.
@@ -710,7 +710,7 @@ pwd = "test123"
 gee_host_url = "https://earthengine.openeo.org"
 api_versions(url = gee_host_url)
 
-gee = connect(host = gee_host_url, version = "0.4.2", user = user, password = pwd, login_type = "basic")
+gee = connect(host = gee_host_url, version = "0.4.2", user = user, password = pwd)
 # also inserting the direct link is possible gee = connect(host = 'https://earthengine.openeo.org/v0.4',user = user,password = pwd)
 
 
@@ -813,7 +813,7 @@ gee_host_url = "https://earthengine.openeo.org"
 user = "group8"
 pwd = "test123"
 
-gee = connect(host = gee_host_url, version = "0.4.2", user = user, password = pwd, login_type = "basic")
+gee = connect(host = gee_host_url, version = "0.4.2", user = user, password = pwd)
 
 # 1. Create a batch job Part 1: create the process graph
 
@@ -876,7 +876,7 @@ pwd = "test123"
 
 gee_host_url = "https://earthengine.openeo.org"
 
-con = connect(host = gee_host_url, version="0.4.2", user = user, password = pwd, login_type = "basic")
+con = connect(host = gee_host_url, version="0.4.2", user = user, password = pwd)
 
 graph = con %>% process_graph_builder()
 

--- a/examples/S1-example.R
+++ b/examples/S1-example.R
@@ -5,7 +5,7 @@ user = "group7"
 pwd = "test123"
 
 # connect  to the back-end and login either via explicit call of login, or use your credentials in the connect function
-gee = connect(host = "https://earthengine.openeo.org",version = "1.0.0", user = user,password = pwd,login_type = "basic")
+gee = connect(host = "https://earthengine.openeo.org",version = "1.0.0", user = user,password = pwd)
 
 # get the process collection to use the predefined processes of the back-end
 p = processes()

--- a/examples/callback-simplification.Rmd
+++ b/examples/callback-simplification.Rmd
@@ -104,7 +104,7 @@ Mapping:
 ## EVI calculation / Band arithmetics:
 
 ```{r, eval=FALSE}
-con = connect(host = host,version=version,user=user,password=pwd,login_type = "basic")
+con = connect(host = host,version=version,user=user,password=pwd)
 graph = process_graph_builder(con = con)
 ```
 
@@ -150,7 +150,7 @@ spectral_reduce = graph$reduce(data = data, dimension = "bands",reducer = functi
 
 ### Version >= 1.0.0:
 ```{r, eval = FALSE}
-con = connect(host = host,version=version,user=user,password=pwd,login_type = "basic")
+con = connect(host = host,version=version,user=user,password=pwd)
 p = processes()
 
 spectral_reduce = p$reduce_dimension(data = data, dimension = "bands", reducer = function(data,context) {
@@ -170,7 +170,7 @@ spectral_reduce = p$reduce_dimension(data = data, dimension = "bands", reducer =
 Either of the following variations can be used:
 
 ```{r, eval=FALSE}
-con = connect(host = host,version=version,user=user,password=pwd,login_type = "basic")
+con = connect(host = host,version=version,user=user,password=pwd)
 graph = process_graph_builder(con = con)
 ```
 
@@ -194,7 +194,7 @@ temporal_reduce = graph$reduce(data=spectral_reduce,dimension = "temporal", redu
 Starting with version 1.0.0 all reducer / aggregation functions are passed as function with specific parameters. Using the process constructor from the `ProcessCollection` or R's aggregation functions are no longer supported due to continuous mismatches between the provided process parameter of the `ProcessArgument` and the process parameter definition of the reducer / aggregation function (often times there are `context` parameter which causes problems with the unary operators). The other problem is that R's aggregation functions also follow another definition schema, so that it cannot reliably mapped, when passed on directly.
 
 ```{r, eval=FALSE}
-con = connect(host = host,version=version,user=user,password=pwd,login_type = "basic")
+con = connect(host = host,version=version,user=user,password=pwd)
 p = processes()
 ```
 

--- a/examples/getting_started.Rmd
+++ b/examples/getting_started.Rmd
@@ -105,13 +105,13 @@ Those functions will open the viewer panel in RStudio which will render the spec
 There are again 2 ways of login, either directly via `connect` by passing additional information about the login type and potentially the login credentials or by calling `login()` manually.
 
 ```{r}
-gee = connect(host = gee_host_url,version = "1.0.1", user = user,password = pwd,login_type = "basic")
+gee = connect(host = gee_host_url,version = "1.0.1", user = user,password = pwd)
 ```
 
 If you want to explore the service before signing in you can always first connect and login later manually. `login()` offers the same login parameter as `connect()`
 
 ```{r, eval=FALSE}
-login(user = user, password = pwd, login_type = "basic")
+login(user = user, password = pwd)
 ```
 
 ### OIDC
@@ -136,7 +136,7 @@ str(provider$google)
 Since we are already connected, we can now login, using the particular oidc provider and the afore mentioned client credentials. The latter can either be stated as a named list or you can state the path to a JSON file, containing the same information.
 
 ```{r, eval = FALSE}
-login(login_type = "oidc", provider = provider$google, config = list(client_id=..., secret=...))
+login(provider = provider$google, config = list(client_id=..., secret=...))
 ```
 
 You will notice that your standard internet browser will open a new website, where you have to enter your credentials. The website will be hosted by your identity provider (here at Google). Your client - the `openeo` package - will be notified by the identity provider and pass on a access code which will be used internally.

--- a/man/OpenEOClient.Rd
+++ b/man/OpenEOClient.Rd
@@ -29,7 +29,7 @@ An R6Class that interacts with an openEO compliant back-end.
   \item{\code{$stopIfNotConnected()}}{throws an error if called and the client is not connected}
   \item{\code{$connect(url=NULL,version=NULL)}}{connects to a specific version of a back-end}
   \item{\code{$api_version()}}{returns the openEO API version this client is compliant to}
-  \item{\code{$login(login_type = NULL,user=NULL, password=NULL,provider=NULL,config=NULL)}}{creates an \code{\link{IAuth}} object based on the login_type}
+  \item{\code{$login(user=NULL, password=NULL,provider=NULL,config=NULL)}}{creates an \code{\link{IAuth}} object}
   \item{\code{$logout()}}{invalidates the access_token and terminates the current session}
   \item{\code{$getAuthClient()}}{returns the authentication client}
   \item{\code{$setAuthClient(value)}}{sets the authentication client if it was configured and set externally}
@@ -51,9 +51,8 @@ An R6Class that interacts with an openEO compliant back-end.
   \item{\code{authorized}}{whether or not the endpoint requires authentication via access_token}
   \item{\code{url}}{url of an openEO back-end either directly versioned or with the separate version statement}
   \item{\code{version}}{the openEO API version to be used, or a list of available API versions if set to NULL}
-  \item{\code{user}}{the user name}
-  \item{\code{password}}{the user password}
-  \item{\code{login_type}}{'basic', 'oidc' or NULL to control the authentication}
+  \item{\code{user}}{the user name for Basic Auth}
+  \item{\code{password}}{the user password for Basic Auth}
   \item{\code{value}}{an authentication object}
 }
 }

--- a/man/OpenEOClient.Rd
+++ b/man/OpenEOClient.Rd
@@ -51,8 +51,8 @@ An R6Class that interacts with an openEO compliant back-end.
   \item{\code{authorized}}{whether or not the endpoint requires authentication via access_token}
   \item{\code{url}}{url of an openEO back-end either directly versioned or with the separate version statement}
   \item{\code{version}}{the openEO API version to be used, or a list of available API versions if set to NULL}
-  \item{\code{user}}{the user name for Basic Auth}
-  \item{\code{password}}{the user password for Basic Auth}
+  \item{\code{user}}{the user name}
+  \item{\code{password}}{the user password}
   \item{\code{value}}{an authentication object}
 }
 }

--- a/man/connect.Rd
+++ b/man/connect.Rd
@@ -26,8 +26,8 @@ service for free through the access to publicly available metadata of data colle
 processing functions. For any computation and the creation of web services, you need to register the openEO partner of
 your choice. There you will get further information on credentials and the log in procedure.
 
-Especially the \code{login_type} and the \code{authType} suggested by the client development guidelines are confusing. Here the login_type deals 
-with considered log in. 'Basic' allows you to use user name and password directly in the call, whereas 'oidc' will
+Especially the \code{authType} suggested by the client development guidelines are confusing.
+'Basic' authentication allows you to use user name and password directly in the call, whereas 'oidc' will
 open a browser window, where you enter you credentials. The authentication on all protected endpoints will later
 use the bearer token that the client has obtained after the log in, unless the authentication was dropped with NULL.
 
@@ -49,12 +49,10 @@ con = connect(host='http://example.openeo.org')
 # connect to a host by direct URL and basic log in
 con = connect(host='http://example.openeo.org/v1.0',
               user='user',
-             password='password',
-             login_type='basic')
+             password='password')
 
 # connect to a host with open id connect authentication
-con = connect(host='http://example.openeo.org',
-              login_type='oidc')
+con = connect(host='http://example.openeo.org')
 
 # connect and login with a named and valid oidc provider
 con = connect(host='http://example.openeo.org',

--- a/man/connect.Rd
+++ b/man/connect.Rd
@@ -26,10 +26,10 @@ service for free through the access to publicly available metadata of data colle
 processing functions. For any computation and the creation of web services, you need to register the openEO partner of
 your choice. There you will get further information on credentials and the log in procedure.
 
-Especially the \code{authType} suggested by the client development guidelines are confusing.
-'Basic' authentication allows you to use user name and password directly in the call, whereas 'oidc' will
-open a browser window, where you enter you credentials. The authentication on all protected endpoints will later
-use the bearer token that the client has obtained after the log in, unless the authentication was dropped with NULL.
+The \code{...} parameter allows you to pass on arguments directly for \code{\link{login}}. If they are omitted the 
+client will only connect to the back-end, but does not do authentication. The user must do that manually afterwards. 
+Based on the provided login parameters user / password or OIDC provider the appropriate login procedure for basic authentication
+or OIDC authentication will be chosen.
 
 The parameter \code{version} is not required. If the service offers a well-known document of the
 service the client will choose an appropriate version (default the most recent production ready version).

--- a/man/login.Rd
+++ b/man/login.Rd
@@ -4,22 +4,18 @@
 \alias{login}
 \title{Log in on a specific back-end}
 \usage{
-login(
-  user = NULL,
-  password = NULL,
-  provider = NULL,
-  config = NULL,
-  con = NULL
-)
+login(user = NULL, password = NULL, provider = NULL, config = NULL, con = NULL)
 }
 \arguments{
-\item{user}{the user name - for Basic Auth only}
+\item{user}{the user name}
 
-\item{password}{the password - for Basic Auth only}
+\item{password}{the password}
 
-\item{provider}{provider object as obtained by 'list_oidc_providers()' or the name of the provider in the provider list. If NULL then the first available provider is chosen from the list.}
+\item{provider}{provider object as obtained by 'list_oidc_providers()' or the name of the provider in the provider list. If NULL
+and \code{provider_type="oidc"} then the first available provider is chosen from the list.}
 
-\item{config}{named list containing 'client_id' and 'secret' or a path to the configuration file (type JSON). If NULL the configuration parameters are taken from the default authentication client of the OIDC provider.}
+\item{config}{named list containing 'client_id' and 'secret' or a path to the configuration file (type JSON). If NULL and 
+\code{provider_type="oidc"} the configuration parameters are taken from the default authentication client of the OIDC provider.}
 
 \item{con}{connected back-end connection (optional) otherwise \code{\link{active_connection}}
 is used.}
@@ -35,10 +31,10 @@ explore the capabilities and want to compute something, then you need to log in 
 \details{
 Based on the general login type (\link{BasicAuth} or \link{OIDCAuth}) there need to be different configurations. The basic
 authentication (if supported) is the simplest login mechanism for which user need to enter their credentials directly as
-\code{user} and \code{password}. The login_type can be neglected if those two parameters are set.
+\code{user} and \code{password}.
 
 For the Open ID connect authentication the user needs to select one of the accepted OIDC providers of 
-\code{\link{list_oidc_providers}} as \code{provider}. Alternatively the name of the provider suffices. 
+\code{\link{list_oidc_providers}} as \code{provider}. Alternatively the name of the provider suffices.
 For further configuration, you can pass a named list of values as \code{config} or
 a file path to a JSON file.
 
@@ -63,13 +59,16 @@ list. You can then use the following values:
 # the URL won't work and is just to demonstrate how to write the code
 con = connect(host='http://example.openeo.org',version='1.0.0')
 
-# also valid basic authentication
+# some back-ends support logging in throug OIDC without any parameters
+login()
+
+# basic authentication, credentials are dummy values
 login(user='user',password='password')
 
-# or alternatively the oidc login
+# or alternatively the OIDC login
 login(provider=provider, config=config)
 
-# with device_code+pkce enabled at the oidc provider you can even use this
+# with device_code+pkce enabled at the OIDC provider you can even use this
 login(provider="your_named_provider")
 
 }

--- a/man/login.Rd
+++ b/man/login.Rd
@@ -7,26 +7,19 @@
 login(
   user = NULL,
   password = NULL,
-  login_type = NULL,
   provider = NULL,
   config = NULL,
   con = NULL
 )
 }
 \arguments{
-\item{user}{the user name}
+\item{user}{the user name - for Basic Auth only}
 
-\item{password}{the password}
+\item{password}{the password - for Basic Auth only}
 
-\item{login_type}{either NULL, 'basic' or 'oidc'. This refers to the login mechanism that shall be used. 
-If the parameter is NULL the authentication method is chosen by the stated other parameters (provider -> oidc, 
-user/password -> basic)}
+\item{provider}{provider object as obtained by 'list_oidc_providers()' or the name of the provider in the provider list. If NULL then the first available provider is chosen from the list.}
 
-\item{provider}{provider object as obtained by 'list_oidc_providers()' or the name of the provider in the provider list. If NULL
-and \code{provider_type="oidc"} then the first available provider is chosen from the list.}
-
-\item{config}{named list containing 'client_id' and 'secret' or a path to the configuration file (type JSON). If NULL and 
-\code{provider_type="oidc"} the configuration parameters are taken from the default authentication client of the OIDC provider.}
+\item{config}{named list containing 'client_id' and 'secret' or a path to the configuration file (type JSON). If NULL the configuration parameters are taken from the default authentication client of the OIDC provider.}
 
 \item{con}{connected back-end connection (optional) otherwise \code{\link{active_connection}}
 is used.}
@@ -45,8 +38,8 @@ authentication (if supported) is the simplest login mechanism for which user nee
 \code{user} and \code{password}. The login_type can be neglected if those two parameters are set.
 
 For the Open ID connect authentication the user needs to select one of the accepted OIDC providers of 
-\code{\link{list_oidc_providers}} as \code{provider}. Alternatively the name of the provider suffices. The login type can be
-neglected if a valid provider was selected. For further configuration, you can pass a named list of values as \code{config} or
+\code{\link{list_oidc_providers}} as \code{provider}. Alternatively the name of the provider suffices. 
+For further configuration, you can pass a named list of values as \code{config} or
 a file path to a JSON file.
 
 There are many different authentication mechanisms for OIDC and OAuth2.0, which OIDC is based on. The 'openeo' package supports
@@ -70,14 +63,11 @@ list. You can then use the following values:
 # the URL won't work and is just to demonstrate how to write the code
 con = connect(host='http://example.openeo.org',version='1.0.0')
 
-# credentials are dummy values
-login(user='user',password='password',login_type='basic', con=con)
-
 # also valid basic authentication
 login(user='user',password='password')
 
 # or alternatively the oidc login
-login(login_type='oidc', provider=provider, config=config)
+login(provider=provider, config=config)
 
 # with device_code+pkce enabled at the oidc provider you can even use this
 login(provider="your_named_provider")

--- a/vignettes/getting_started.Rmd
+++ b/vignettes/getting_started.Rmd
@@ -151,7 +151,7 @@ service_types
 user = ""
 pwd = ""
 
-login(user = user,password = pwd,login_type = "basic")
+login(user = user,password = pwd)
 ```
 
 Note: You might explore more data collections and processes once you are registered and logged in. Without logging in you can just see the free data sets that do not conflict with any terms of use.


### PR DESCRIPTION
Several changes in here:
1. Use OIDC as default, no login_type required any longer
2. Thus, removed/deprecated login_type
3. Use list of default_clients (API compliant) instead of default_client (which is a bug on VITOs side)
4. Properly detect default client IDs for grants that don't need a secret (i.e. don't do this for authcode without PKCE)
5. Improve detection for default client ID
6. clean-up (hopefully)