### PR TITLE
Device Code Auth with Jupyter and httr2

### DIFF
--- a/R/authentication.R
+++ b/R/authentication.R
@@ -403,6 +403,10 @@ AbstractOIDCAuthentication <- R6Class(
       return(token$expires_at <= Sys.time())
     },
     
+    isInteractive = function() {
+      return(if (is_jupyter()) TRUE else rlang::is_interactive())
+    },
+    
     decodeToken = function(access_token, token_part) {
       tokens <- unlist(strsplit(access_token, "\\."))
       fromJSON(rawToChar(base64decode(tokens[token_part])))
@@ -447,12 +451,16 @@ OIDCDeviceCodeFlow <- R6Class(
         token_url = private$endpoints$token_endpoint,
         name = "openeo-r-oidc-auth"
       )
-      
-      private$auth = oauth_flow_device(client = client,
-                                       auth_url = private$endpoints$device_authorization_endpoint,
-                                       scope=paste0(private$scopes,collapse=" "))
-      
-      
+
+      private$auth = rlang::with_interactive(
+                      oauth_flow_device(
+                        client = client,
+                        auth_url = private$endpoints$device_authorization_endpoint,
+                        scope = paste0(private$scopes, collapse = " ")
+                      ),
+                      value = private$isInteractive()
+                    )
+
       invisible(self)
     }
   ),
@@ -485,12 +493,17 @@ OIDCDeviceCodeFlowPkce <- R6Class(
         token_url = private$endpoints$token_endpoint,
         name = "openeo-r-oidc-auth"
       )
-      
-      private$auth = oauth_flow_device(client = client,
-                                       auth_url = private$endpoints$device_authorization_endpoint,
-                                       scope=paste0(private$scopes,collapse=" "),pkce = TRUE)
-      
-      
+
+      private$auth = rlang::with_interactive(
+                      oauth_flow_device(
+                        client = client,
+                        auth_url = private$endpoints$device_authorization_endpoint,
+                        scope = paste0(private$scopes, collapse = " "),
+                        pkce = TRUE
+                      ),
+                      value = private$isInteractive()
+                    )
+
       invisible(self)
     }
   ),
@@ -525,15 +538,18 @@ OIDCAuthCodeFlowPKCE <- R6Class(
         token_url = private$endpoints$token_endpoint,
         name = "openeo-r-oidc-auth"
       )
-      
-      private$auth = oauth_flow_auth_code(client = client,
-                                       auth_url = private$endpoints$authorization_endpoint,
-                                       scope=paste0(private$scopes,collapse=" "),
-                                       pkce = TRUE,
-                                       port=1410
-                                       )
-      
-      
+
+      private$auth = rlang::with_interactive(
+                      oauth_flow_auth_code(
+                        client = client,
+                        auth_url = private$endpoints$authorization_endpoint,
+                        scope = paste0(private$scopes, collapse = " "),
+                        pkce = TRUE,
+                        port = 1410
+                      ),
+                      value = private$isInteractive()
+                    )
+
       invisible(self)
     }
   ),
@@ -568,13 +584,17 @@ OIDCAuthCodeFlow <- R6Class(
         token_url = private$endpoints$token_endpoint,
         name = "openeo-r-oidc-auth"
       )
-      
-      private$auth = oauth_flow_auth_code(client = client,
-                                          auth_url = private$endpoints$authorization_endpoint,
-                                          scope=paste0(private$scopes,collapse=" "),
-                                          pkce = FALSE,
-                                          port=1410
-      )
+
+      private$auth = rlang::with_interactive(
+                      oauth_flow_auth_code(
+                        client = client,
+                        auth_url = private$endpoints$authorization_endpoint,
+                        scope = paste0(private$scopes, collapse = " "),
+                        pkce = FALSE,
+                        port = 1410
+                      ),
+                      value = private$isInteractive()
+                    )
     }
   ),
   # private ====

--- a/R/httr2_device_code.R
+++ b/R/httr2_device_code.R
@@ -36,7 +36,7 @@ oauth_flow_fetch = function (req) {
 #' @importFrom glue glue
 oauth_flow_device = function (client, auth_url, pkce = FALSE, scope = NULL, auth_params = list(), 
                               token_params = list()) {
-  httr2:::oauth_flow_check("device", client)
+  httr2:::oauth_flow_check("device", client, interactive = TRUE)
   
   if (pkce) { # added this
     code <- oauth_flow_auth_code_pkce()

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -148,3 +148,18 @@ status = function(x, ...) {
     return(ns[subset])
   }
 }
+
+# Is this in a Jupyter notebook?
+is_jupyter = function() {
+  return (isTRUE(getOption('jupyter.in_kernel')))
+}
+
+# Is this in a RStudio notebook?
+is_rstudio_nb = function() {
+  return (isTRUE(getOption('rstudio.notebook.executing')))
+}
+
+# Is this in a RMarkdown / knitr context?
+is_rmd = function() {
+  return (isTRUE(getOption('knitr.in.progress')) && knitr::is_html_output() == TRUE)
+}

--- a/R/viewer.R
+++ b/R/viewer.R
@@ -252,21 +252,6 @@ collection_viewer = function(x = NULL, con = NULL) {
   }, error = .capturedErrorToMessage)
 }
 
-# Is this in a Jupyter notebook?
-is_jupyter = function() {
-  return (isTRUE(getOption('jupyter.in_kernel')))
-}
-
-# Is this in a RStudio notebook?
-is_rstudio_nb = function() {
-  return (isTRUE(getOption('rstudio.notebook.executing')))
-}
-
-# Is this in a RMarkdown / knitr context?
-is_rmd = function() {
-  return (isTRUE(getOption('knitr.in.progress')) && knitr::is_html_output() == TRUE)
-}
-
 # Is this in a HTML context (any onf the above)?
 is_html_context = function() {
   return (is_jupyter() || is_rstudio_nb() || is_rmd())


### PR DESCRIPTION
Wraps the httr2 device_code flow calls with `with_interactive` and sets interactive mode for Jupyter to True, otherwise keeps it as is. Does this also make sense to you, @flahn? Tested with RStudio and JupyterLab.

Fixes #95 (and #118)