### PR TITLE
Always show a URL in Jupyter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Suggests:
     DT
 Imports:
     jsonlite,
-    httr2 (>= 0.2.0),
+    httr2 (>= 0.2.2),
     methods,
     R6,
     lubridate,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Version 1.2.1.9000 Upcoming Version
+
+## Fixes
+* OIDC authentication on remote machines prints now correctly URL and device code after fixes in httr2 package, now version 0.2.2 or higher is required (@m-mohr, @flahn, #131, #119)
+
 # version 1.2.1
 
 ## Added

--- a/R/authentication.R
+++ b/R/authentication.R
@@ -405,7 +405,7 @@ AbstractOIDCAuthentication <- R6Class(
     },
     
     isInteractive = function() {
-      return(if (is_jupyter()) TRUE else rlang::is_interactive())
+      return(if (is_jupyter()) FALSE else rlang::is_interactive())
     },
     
     decodeToken = function(access_token, token_part) {


### PR DESCRIPTION
Not tested yet. We need to test a locally hosted Jupyter and a remote one.

Related: #119

We need to check whether we run into this issue again: https://github.com/r-lib/httr2/pull/103

Maybe we can remove the code completely?