### PR TITLE
Fix capabilities request issue

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -367,9 +367,8 @@ OpenEOClient <- R6Class(
     
     getCapabilities = function() {
       if (is.null(private$capabilities)) {
-        endpoint = "/"
         tryCatch({
-          private$capabilities = private$GET(endpoint = endpoint)
+          private$capabilities = private$GET(endpoint = "")
             
           class(private$capabilities) = "OpenEOCapabilities"
         }, error = .capturedErrorToMessage)


### PR DESCRIPTION
The implementation of `getCapabilities` sent a request with two slashes at the end, so if you connect to `https://example.com` it would send the capabilities request to `https://example.com//`. For some back-ends, this leads to an error.

This solves the issue that we encountered with the [openeogdalcubes](https://github.com/PondiB/openeogdalcubes) implementation. cc @PondiB