### PR TITLE
Fix for httr2 1.2.0

### DIFF
--- a/R/authentication.R
+++ b/R/authentication.R
@@ -531,8 +531,7 @@ OIDCAuthCodeFlowPKCE <- R6Class(
                         client = private$oauth_client,
                         auth_url = private$endpoints$authorization_endpoint,
                         scope = paste0(private$scopes, collapse = " "),
-                        pkce = TRUE,
-                        port = 1410
+                        pkce = TRUE
                       ),
                       value = private$isInteractive()
                     )
@@ -571,8 +570,7 @@ OIDCAuthCodeFlow <- R6Class(
                         client = private$oauth_client,
                         auth_url = private$endpoints$authorization_endpoint,
                         scope = paste0(private$scopes, collapse = " "),
-                        pkce = FALSE,
-                        port = 1410
+                        pkce = FALSE
                       ),
                       value = private$isInteractive()
                     )


### PR DESCRIPTION
This release will remove the deprecated `port` argument from `oauth_flow_auth_code`. I don't think your usage here was actually doing anything, so it can be safely removed.